### PR TITLE
Application update correct handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ It includes all the common code from the sample including AndroidManifest.xml th
 * in your `Application` implement [GcmListener](http://github.com/inloop/easygcm/blob/master/easygcm/src/main/java/eu/inloop/easygcm/GcmListener.java) interface with two methods: 
  * `onMessage()` (don't forget to call wakeLockRelease.release() after you are done)
  * `sendRegistrationIdToBackend()`
-* in your MainActivity `onCreate()`, call `GcmHelper.init(this, "your-google-dev-project-id");`
+* in your MainActivity `onCreate()`, call `GcmHelper.init(this);`
+* define `easygcm_sender_id` string resource and set it to your GCM Sender ID
 
 That's it. You might also want to use Gradle task for sending push notifications to your device:
 

--- a/easygcm-sample/build.gradle
+++ b/easygcm-sample/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        mavenCentral()
         mavenLocal()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.1.0'
@@ -25,12 +25,14 @@ android {
         // unfortunately, this is needed with latest tools, because of this bug:
         // https://code.google.com/p/android/issues/detail?id=143836
         manifestPlaceholders = [ localApplicationId:"eu.inloop.easygcm.sample" ]
+
+        versionCode 9
     }
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
 }
 
 dependencies {

--- a/easygcm-sample/src/main/java/eu/inloop/easygcm/sample/App.java
+++ b/easygcm-sample/src/main/java/eu/inloop/easygcm/sample/App.java
@@ -22,5 +22,4 @@ public class App extends Application implements GcmListener {
     public void sendRegistrationIdToBackend(String registrationId) {
         
     }
-
 }

--- a/easygcm-sample/src/main/java/eu/inloop/easygcm/sample/MainActivity.java
+++ b/easygcm-sample/src/main/java/eu/inloop/easygcm/sample/MainActivity.java
@@ -8,13 +8,11 @@ import eu.inloop.easygcm.GcmHelper;
 
 public class MainActivity extends Activity {
 
-    private String SENDER_ID = "835909578313"; // easygcm-sample project
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
-        GcmHelper.init(this, SENDER_ID);
+        GcmHelper.init(this);
     }
 
 }

--- a/easygcm-sample/src/main/res/values/config.xml
+++ b/easygcm-sample/src/main/res/values/config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="easygcm_sender_id" translatable="false">835909578313</string>
+    
+</resources>

--- a/easygcm-sample/src/main/res/values/strings.xml
+++ b/easygcm-sample/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
 
     <string name="send">Send</string>
     <string name="clear">Clear</string>
+
 </resources>

--- a/easygcm/src/main/AndroidManifest.xml
+++ b/easygcm/src/main/AndroidManifest.xml
@@ -45,6 +45,14 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name="eu.inloop.easygcm.GcmPackageReplacedReceiver">
+            <!-- Useful for detecting when the application is upgraded so we can request a new GCM ID -->
+            <!-- MY_PACKAGE_REPLACED only alerts for this same app, and it is only available on API 12 and up -->
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
         <service android:name="eu.inloop.easygcm.GcmIntentService" />
         
         <meta-data

--- a/easygcm/src/main/java/eu/inloop/easygcm/GcmIntentService.java
+++ b/easygcm/src/main/java/eu/inloop/easygcm/GcmIntentService.java
@@ -5,6 +5,7 @@ import com.google.android.gms.gcm.GoogleCloudMessaging;
 import android.app.IntentService;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v4.content.WakefulBroadcastReceiver;
 
 /**
  * This {@code IntentService} does the actual handling of the GCM message.
@@ -32,7 +33,7 @@ public class GcmIntentService extends IntentService {
             // Release the wake lock provided by the WakefulBroadcastReceiver.
         } else {
             // Release the wake lock provided by the WakefulBroadcastReceiver.
-            GcmBroadcastReceiver.completeWakefulIntent(intent);
+            WakefulBroadcastReceiver.completeWakefulIntent(intent);
             throw new IllegalStateException("Application must implement GcmListener interface!");
         }
 

--- a/easygcm/src/main/java/eu/inloop/easygcm/GcmPackageReplacedReceiver.java
+++ b/easygcm/src/main/java/eu/inloop/easygcm/GcmPackageReplacedReceiver.java
@@ -1,0 +1,28 @@
+package eu.inloop.easygcm;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.content.WakefulBroadcastReceiver;
+import android.util.Log;
+
+public class GcmPackageReplacedReceiver extends WakefulBroadcastReceiver {
+    @Override
+    public void onReceive(Context context, final Intent intent) {
+        if (intent != null && intent.getAction().equals(Intent.ACTION_MY_PACKAGE_REPLACED)) {
+            if (context.getApplicationContext() instanceof GcmListener) {
+                if (GcmHelper.sLoggingEnabled) {
+                    Log.d(GcmUtils.TAG, "Received application update broadcast");
+                }
+                GcmHelper.getInstance().registerInBackground(context, new GcmHelper.RegistrationListener() {
+                    @Override
+                    public void onFinish() {
+                        WakefulBroadcastReceiver.completeWakefulIntent(intent);
+                    }
+                });
+            } else {
+                WakefulBroadcastReceiver.completeWakefulIntent(intent);
+                throw new IllegalStateException("Application must implement GcmListener interface!");
+            }
+        }
+    }
+}

--- a/easygcm/src/main/java/eu/inloop/easygcm/GcmUtils.java
+++ b/easygcm/src/main/java/eu/inloop/easygcm/GcmUtils.java
@@ -1,10 +1,13 @@
 package eu.inloop.easygcm;
 
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.util.Log;
 
 class GcmUtils {
 
-    private static final String TAG = "easygcm";
+    static final String TAG = "easygcm";
 
     static class Logger {
         static void d(String message) {
@@ -16,4 +19,17 @@ class GcmUtils {
         }
     }
 
+    /**
+     * @return Application's version code from the {@code PackageManager}.
+     */
+    static int getAppVersion(Context context) {
+        try {
+            final PackageInfo packageInfo = context.getPackageManager()
+                    .getPackageInfo(context.getPackageName(), 0);
+            return packageInfo.versionCode;
+        } catch (PackageManager.NameNotFoundException e) {
+            // should never happen
+            throw new RuntimeException("Could not get package name: " + e);
+        }
+    }
 }

--- a/easygcm/src/main/java/eu/inloop/easygcm/WakeLockRelease.java
+++ b/easygcm/src/main/java/eu/inloop/easygcm/WakeLockRelease.java
@@ -1,6 +1,7 @@
 package eu.inloop.easygcm;
 
 import android.content.Intent;
+import android.support.v4.content.WakefulBroadcastReceiver;
 
 public class WakeLockRelease {
 
@@ -14,6 +15,6 @@ public class WakeLockRelease {
      * Call this after you are done with processing of the broadcast.
      */
     public void release() {
-        GcmBroadcastReceiver.completeWakefulIntent(mWakefulIntent);
+        WakefulBroadcastReceiver.completeWakefulIntent(mWakefulIntent);
     }
 }

--- a/easygcm/src/main/res/values/config.xml
+++ b/easygcm/src/main/res/values/config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Override in your application to provide the GCM senderId -->
+    <!--suppress CheckTagEmptyBody -->
+    <string name="easygcm_sender_id" translatable="false"></string>
+</resources>


### PR DESCRIPTION
Add support for MY_PACKAGE_REPLACED (https://medium.com/@murki/gcm-push-notifications-registration-done-right-7aba759d1d55). This fixes a case where the application is updated, the registration ID changes and the application stops receiving push messages until the application is started again.

A check was added to prevent double registration on GCM if the process is already running.