### PR TITLE
Support for setting custom GcmListener

### DIFF
--- a/easygcm/src/main/java/eu/inloop/easygcm/GcmIntentService.java
+++ b/easygcm/src/main/java/eu/inloop/easygcm/GcmIntentService.java
@@ -28,14 +28,7 @@ public class GcmIntentService extends IntentService {
         // in your BroadcastReceiver.
         String messageType = gcm.getMessageType(intent);
 
-        if (getApplication() instanceof GcmListener) {
-            ((GcmListener) getApplication()).onMessage(messageType, extras, new WakeLockRelease(intent));
-            // Release the wake lock provided by the WakefulBroadcastReceiver.
-        } else {
-            // Release the wake lock provided by the WakefulBroadcastReceiver.
-            WakefulBroadcastReceiver.completeWakefulIntent(intent);
-            throw new IllegalStateException("Application must implement GcmListener interface!");
-        }
+        GcmHelper.getInstance().getGcmListener(getApplication()).onMessage(messageType, extras, new WakeLockRelease(intent));
 
     }
 

--- a/easygcm/src/main/java/eu/inloop/easygcm/GcmPackageReplacedReceiver.java
+++ b/easygcm/src/main/java/eu/inloop/easygcm/GcmPackageReplacedReceiver.java
@@ -9,20 +9,15 @@ public class GcmPackageReplacedReceiver extends WakefulBroadcastReceiver {
     @Override
     public void onReceive(Context context, final Intent intent) {
         if (intent != null && intent.getAction().equals(Intent.ACTION_MY_PACKAGE_REPLACED)) {
-            if (context.getApplicationContext() instanceof GcmListener) {
-                if (GcmHelper.sLoggingEnabled) {
-                    Log.d(GcmUtils.TAG, "Received application update broadcast");
-                }
-                GcmHelper.getInstance().registerInBackground(context, new GcmHelper.RegistrationListener() {
-                    @Override
-                    public void onFinish() {
-                        WakefulBroadcastReceiver.completeWakefulIntent(intent);
-                    }
-                });
-            } else {
-                WakefulBroadcastReceiver.completeWakefulIntent(intent);
-                throw new IllegalStateException("Application must implement GcmListener interface!");
+            if (GcmHelper.sLoggingEnabled) {
+                Log.d(GcmUtils.TAG, "Received application update broadcast");
             }
+            GcmHelper.getInstance().registerInBackground(context, new GcmHelper.RegistrationListener() {
+                @Override
+                public void onFinish() {
+                    WakefulBroadcastReceiver.completeWakefulIntent(intent);
+                }
+            });
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 06 12:45:10 CEST 2014
+#Tue Mar 03 16:32:54 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
We would like to integrate your library in our library and we don’t
have access to the Application instance. That’s why we can’t implement
GcmListener directly. This commit adds method setGcmListener() which
should be (optionally) called in Application.onCreate()